### PR TITLE
Updating rubygems source to use HTTPS.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 
 gem 'chef'
 gem 'chefspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     builder (3.1.4)
     bunny (0.7.9)


### PR DESCRIPTION
This gets rid of the warning about using deprecated :rubygems source when running commands through bundler.
