### PR TITLE
Update phantomjs version

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,3 @@
 default['phantomjs'] = {
-  'version' => '1.7.0'
+  'version' => '1.9.0'
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -15,4 +15,4 @@ end
 attribute 'version',
   :display_name => 'Version',
   :description => 'The Version of phantomjs to install',
-  :default => '1.7.0'
+  :default => '1.9.0'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -22,9 +22,7 @@ describe 'phantomjs::default' do
   end
 
   let(:runner) do
-    ChefSpec::ChefRunner.new do |node|
-      node.override['phantomjs']['version'] = '1.7.0'
-    end.converge('phantomjs::default')
+    ChefSpec::ChefRunner.new.converge('phantomjs::default')
   end
 
   it 'should fetch the correct remote_file' do

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -26,15 +26,15 @@ describe 'phantomjs::default' do
   end
 
   it 'should fetch the correct remote_file' do
-    runner.should create_remote_file '/usr/local/src/phantomjs-1.7.0-linux-i386.tar.bz2'
+    runner.should create_remote_file '/usr/local/src/phantomjs-1.9.0-linux-i386.tar.bz2'
   end
 
   it 'should extract the binary' do
-    runner.should execute_command 'tar -xvjf /usr/local/src/phantomjs-1.7.0-linux-i386.tar.bz2 -C /usr/local/'
+    runner.should execute_command 'tar -xvjf /usr/local/src/phantomjs-1.9.0-linux-i386.tar.bz2 -C /usr/local/'
   end
 
   it 'should symlink the binary to /usr/local/bin' do
     runner.should create_link '/usr/local/bin/phantomjs'
-    runner.link('/usr/local/bin/phantomjs').should link_to('/usr/local/phantomjs-1.7.0-linux-i386/bin/phantomjs')
+    runner.link('/usr/local/bin/phantomjs').should link_to('/usr/local/phantomjs-1.9.0-linux-i386/bin/phantomjs')
   end
 end


### PR DESCRIPTION
These commits A) update the default phantomjs version to 1.9, and B) remove hardcoding of the phantomjs is spec setup.
