### PR TITLE
Update Phantomjs version to 1.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ All attributes are namespaced under `node['phantomjs']`.
       <td>version</td>
       <td>The version to install</td>
       <td><tt>1.0.0</tt></td>
-      <td><tt>1.9.0</tt></td>
+      <td><tt>1.9.2</tt></td>
     </tr>
     <tr>
       <td>packages</td>

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,7 +24,7 @@
 #
 
 # The version of phantomjs to install
-default['phantomjs']['version'] = '1.9.1'
+default['phantomjs']['version'] = '1.9.2'
 
 # The list of packages to install
 default['phantomjs']['packages'] = []

--- a/attributes/rhel.rb
+++ b/attributes/rhel.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: phantomjs
-# Attribute:: rehl
+# Attribute:: rhel
 #
 # Copyright 2012-2013, Seth Vargo (sethvargo@gmail.com)
 # Copyright 2012-2013, CustomInk


### PR DESCRIPTION
This pull request updates the Phantomjs version from 1.9.1 to 1.9.2 and also fixes a typo with the attributes file for RHEL based platforms
