### PR TITLE
Change to 1.8.6 hash syntax

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sethvargo@gmail.com'
 license 'Apache 2.0'
 description 'Installs/Configures phantomjs'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.3'
+version '1.0.4'
 
 %w(amazon centos debian fedora gentoo oracle rhel scientific ubuntu windows).each do |os|
   supports os

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -7,7 +7,7 @@ describe 'phantomjs::default' do
   let(:basename) { 'phantomjs-1.0.0-linux-x86' }
 
   let(:runner) {
-    runner = ChefSpec::ChefRunner.new(platform: 'ubuntu', version: '12.04')
+    runner = ChefSpec::ChefRunner.new(:platform => 'ubuntu', :version => '12.04')
 
     runner.node.set['phantomjs']['version']  = version
     runner.node.set['phantomjs']['base_url'] = base_url

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,5 +2,5 @@ require 'berkshelf'
 require 'chefspec'
 
 Berkshelf.ui.mute {
-  Berkshelf::Berksfile.from_file('Berksfile').install(path: 'vendor/cookbooks')
+  Berkshelf::Berksfile.from_file('Berksfile').install(:path => 'vendor/cookbooks')
 }

--- a/spec/structure_spec.rb
+++ b/spec/structure_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'phantomjs::structure' do
   let(:src_dir) { '/foo/bar/zip' }
   let(:runner) do
-    runner = ChefSpec::ChefRunner.new(platform: 'ubuntu', version: '12.04')
+    runner = ChefSpec::ChefRunner.new(:platform => 'ubuntu', :version => '12.04')
     runner.node.set['phantomjs']['src_dir'] = src_dir
     runner.converge('phantomjs::structure')
   end


### PR DESCRIPTION
Unfortunately for us, we have some people who are using Chef 10, which uses 1.8.6 hash syntax. Just wanted to see you'd be willing to accept these changes so people on Chef 10's tests will function. Thanks!
