### PR TITLE
Delaying attribute string interpolation

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -46,4 +46,4 @@ default['phantomjs']['base_url'] = 'https://bitbucket.org/ariya/phantomjs/downlo
 
 # The name of the tarball to download (this is automatically calculated from
 # the phantomjs version and kernel type)
-default['phantomjs']['basename'] = "phantomjs-#{node['phantomjs']['version']}-linux-#{node['kernel']['machine']}"
+default['phantomjs']['basename'] = "phantomjs-%{version}-linux-%{machine}"

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -28,7 +28,7 @@ include_recipe 'phantomjs::structure'
 node['phantomjs']['packages'].each { |name| package name }
 
 version  = node['phantomjs']['version']
-base_url = node['phantomjs']['base_url']
+base_url = node['phantomjs']['base_url'] % { version: version }
 src_dir  = node['phantomjs']['src_dir']
 basename = node['phantomjs']['basename'] % { version: version, machine: node['kernel']['machine'] }
 checksum = node['phantomjs']['checksum']

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -30,7 +30,7 @@ node['phantomjs']['packages'].each { |name| package name }
 version  = node['phantomjs']['version']
 base_url = node['phantomjs']['base_url']
 src_dir  = node['phantomjs']['src_dir']
-basename = node['phantomjs']['basename']
+basename = node['phantomjs']['basename'] % { version: version, machine: node['kernel']['machine'] }
 checksum = node['phantomjs']['checksum']
 
 remote_file "#{src_dir}/#{basename}.tar.bz2" do


### PR DESCRIPTION
Inspired by https://coderanger.net/derived-attributes/

I separated into two commits because the base_url interpolation is mostly aimed at more easily pulling PhantomJS from a GitHub release, which have a version baked into the URL. So if that's controversial perhaps you can just cherry-pick the other :smile:
